### PR TITLE
j1939: don't fail if j1939 module is not loaded or no module at all

### DIFF
--- a/j1939/run_all.sh
+++ b/j1939/run_all.sh
@@ -5,11 +5,12 @@ set -e
 for f in j1939*.sh; do
 	echo "##############################################"
 	pre=$(lsmod | awk '/^can_j1939/ { print $3 }')
+	pre=${pre:-0}
 	echo "run: $f"
 	./$f "${@}"
 	echo "done: $f"
 	post=$(lsmod | awk '/^can_j1939/ { print $3 }')
-	if [ $pre -ne $post ]; then
+	if lsmod | grep can_j1939 && [ $pre -ne $post ]; then
 		echo "module usage: before start: $pre"
 		echo "              after finish: $post"
 		exit 1


### PR DESCRIPTION
Fixes: d2cbeb0e0c20 ("j1939: test j1939 module usage for proper cleanup")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>